### PR TITLE
Support aliases for JDK architecture

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -266,6 +266,27 @@ describe('installer tests', () => {
     expect(fs.existsSync(path.join(JavaDir, 'bin'))).toBe(true);
   }, 100000);
 
+  it('Downloads JDK with architecture alias x86_64', async () => {
+    await installer.getAdoptOpenJDK(
+      'ga',
+      '11',
+      'jdk',
+      'hotspot',
+      'x86_64',
+      'normal',
+      'jdk-11.0.6+10',
+      ''
+    );
+    const JavaDir = path.join(
+      toolDir,
+      toolName,
+      `1.0.0-ga-11-jdk-hotspot-${os}-x64-normal-jdk-11.0.6`,
+      'x64'
+    );
+
+    expect(fs.existsSync(path.join(JavaDir, 'bin'))).toBe(true);
+  }, 100000);
+
   it('Downloads JRE with normal syntax', async () => {
     await installer.getAdoptOpenJDK(
       'ga',

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -451,7 +451,12 @@ async function downloadJavaBinary(
       tempDir
     );
     core.debug(`JDK extracted to ${jdkDir}`);
-    toolPath = await tc.cacheDir(jdkDir, toolName, versionSpec, normalizedArchitecture);
+    toolPath = await tc.cacheDir(
+      jdkDir,
+      toolName,
+      versionSpec,
+      normalizedArchitecture
+    );
   }
 
   let extendedJavaHome = `JAVA_HOME_${version}_${normalizedArchitecture}`;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,6 +13,12 @@ const IS_WINDOWS = process.platform === 'win32';
 const IS_MACOS = process.platform === 'darwin';
 const toolName = 'AdoptOpenJDK';
 const os = getOsString(process.platform);
+const architectureAliases = new Map<string, string>([
+  ['amd64', 'x64'],
+  ['i686', 'x32'],
+  ['x86', 'x32'],
+  ['x86_64', 'x64']
+]);
 
 if (!tempDirectory) {
   let baseLocation;
@@ -401,17 +407,18 @@ async function downloadJavaBinary(
   release: string,
   jdkFile: string
 ): Promise<void> {
+  const normalizedArchitecture = architectureAliases.get(arch) || arch;
   const versionSpec = getCacheVersionSpec(
     release_type,
     version,
     image_type,
     jvm_impl,
     os,
-    arch,
+    normalizedArchitecture,
     heap_size,
     release
   );
-  let toolPath = tc.find(toolName, versionSpec, arch);
+  let toolPath = tc.find(toolName, versionSpec, normalizedArchitecture);
 
   if (toolPath) {
     core.debug(`Tool found in cache ${toolPath}`);
@@ -425,7 +432,7 @@ async function downloadJavaBinary(
         image_type,
         jvm_impl,
         os,
-        arch,
+        normalizedArchitecture,
         heap_size,
         release
       );
@@ -444,10 +451,10 @@ async function downloadJavaBinary(
       tempDir
     );
     core.debug(`JDK extracted to ${jdkDir}`);
-    toolPath = await tc.cacheDir(jdkDir, toolName, versionSpec, arch);
+    toolPath = await tc.cacheDir(jdkDir, toolName, versionSpec, normalizedArchitecture);
   }
 
-  let extendedJavaHome = `JAVA_HOME_${version}_${arch}`;
+  let extendedJavaHome = `JAVA_HOME_${version}_${normalizedArchitecture}`;
   core.exportVariable(extendedJavaHome, toolPath); //TODO: remove for v2
   // For portability reasons environment variables should only consist of
   // uppercase letters, digits, and the underscore. Therefore we convert


### PR DESCRIPTION
Instead of only supporting the exact architecture terminology used by AdoptOpenJDK,
`joschi/setup-jdk` now also support aliases such as `x86` or `i686` for `x32` and
`amd64` or `x86_64` for `x64`.

Closes #7