### PR TITLE
Restore compatibility with joschi/setup-jdk@v1 for `java-version`

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -345,7 +345,7 @@ describe('installer tests', () => {
     return;
   });
 
-  it('GitHub issue #9: Allow openjdk\d+ as Java release version', async () => {
+  it('GitHub issue #9: Allow openjdk[0-9]+ as Java release version', async () => {
     await installer.getAdoptOpenJDK(
       'ga',
       'openjdk14',

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -344,4 +344,25 @@ describe('installer tests', () => {
     expect(thrown).toBe(true);
     return;
   });
+
+  it('GitHub issue #9: Allow openjdk\d+ as Java release version', async () => {
+    await installer.getAdoptOpenJDK(
+      'ga',
+      'openjdk14',
+      'jdk',
+      'hotspot',
+      'x64',
+      'normal',
+      'latest',
+      ''
+    );
+    const JavaDir = path.join(
+      toolDir,
+      toolName,
+      `1.0.0-ga-14-jdk-hotspot-${os}-x64-normal-latest`,
+      'x64'
+    );
+
+    expect(fs.existsSync(path.join(JavaDir, 'bin'))).toBe(true);
+  }, 100000);
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4687,13 +4687,13 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 let tempDirectory = process.env['RUNNER_TEMP'] || '';
 const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
 const exec = __importStar(__webpack_require__(986));
-const httpm = __importStar(__webpack_require__(539));
-const tc = __importStar(__webpack_require__(533));
 const fs = __importStar(__webpack_require__(747));
+const httpm = __importStar(__webpack_require__(539));
+const io = __importStar(__webpack_require__(1));
 const path = __importStar(__webpack_require__(622));
 const semver = __importStar(__webpack_require__(280));
+const tc = __importStar(__webpack_require__(533));
 const IS_WINDOWS = process.platform === 'win32';
 const IS_MACOS = process.platform === 'darwin';
 const toolName = 'AdoptOpenJDK';
@@ -5008,7 +5008,8 @@ function getJdkDirectory(destinationFolder) {
 function downloadJavaBinary(release_type, version, image_type, jvm_impl, os, arch, heap_size, release, jdkFile) {
     return __awaiter(this, void 0, void 0, function* () {
         const normalizedArchitecture = architectureAliases.get(arch) || arch;
-        const versionSpec = getCacheVersionSpec(release_type, version, image_type, jvm_impl, os, normalizedArchitecture, heap_size, release);
+        const normalizedVersion = version.replace('openjdk', '');
+        const versionSpec = getCacheVersionSpec(release_type, normalizedVersion, image_type, jvm_impl, os, normalizedArchitecture, heap_size, release);
         let toolPath = tc.find(toolName, versionSpec, normalizedArchitecture);
         if (toolPath) {
             core.debug(`Tool found in cache ${toolPath}`);
@@ -5017,7 +5018,8 @@ function downloadJavaBinary(release_type, version, image_type, jvm_impl, os, arc
             let compressedFileExtension = '';
             if (!jdkFile) {
                 core.debug('Downloading JDK from AdoptOpenJDK');
-                const url = getAdoptOpenJdkUrl(release_type, version, image_type, jvm_impl, os, normalizedArchitecture, heap_size, release);
+                const url = getAdoptOpenJdkUrl(release_type, normalizedVersion, image_type, jvm_impl, os, normalizedArchitecture, heap_size, release);
+                core.debug(`AdoptOpenJDK URL: ${url}`);
                 jdkFile = yield tc.downloadTool(url);
                 compressedFileExtension = IS_WINDOWS ? '.zip' : '.tar.gz';
             }
@@ -5027,7 +5029,7 @@ function downloadJavaBinary(release_type, version, image_type, jvm_impl, os, arc
             core.debug(`JDK extracted to ${jdkDir}`);
             toolPath = yield tc.cacheDir(jdkDir, toolName, versionSpec, normalizedArchitecture);
         }
-        let extendedJavaHome = `JAVA_HOME_${version}_${normalizedArchitecture}`;
+        let extendedJavaHome = `JAVA_HOME_${normalizedVersion}_${normalizedArchitecture}`;
         core.exportVariable(extendedJavaHome, toolPath); //TODO: remove for v2
         // For portability reasons environment variables should only consist of
         // uppercase letters, digits, and the underscore. Therefore we convert
@@ -5038,7 +5040,7 @@ function downloadJavaBinary(release_type, version, image_type, jvm_impl, os, arc
         core.exportVariable(extendedJavaHome, toolPath);
         core.addPath(path.join(toolPath, 'bin'));
         core.setOutput('path', toolPath);
-        core.setOutput('version', version);
+        core.setOutput('version', normalizedVersion);
     });
 }
 


### PR DESCRIPTION
The normalization of the `java-version` setting to treat "openjdk14" as a valid Java release version was accidentally dropped while moving to joschi/setup-jdk 2.x.

Closes #9